### PR TITLE
analytics.pyのデータパスを修正

### DIFF
--- a/streamlit/analytics.py
+++ b/streamlit/analytics.py
@@ -18,7 +18,7 @@ with st.sidebar:
     ['transactionhistory'])
     base_data_name=st.selectbox(
     '対象のデータ',
-    [f for f in os.listdir("data/transactionhistory") if f.endswith(".csv")])
+    [f for f in os.listdir(f"data/analytics/{target_folder}") if f.endswith(".csv")])
 
     min_area = 0.0
     max_area = 150.0
@@ -39,7 +39,7 @@ with st.sidebar:
 #販売終了年月が空白のでーたは表示しないようにするか切り替えられるボタンがほしい
 hide_empty = st.checkbox("販売終了年月が空白のデータを表示しない", value=True)
 
-shows = pd.read_csv(f"data/{target_folder}/{base_data_name}",index_col=0)
+shows = pd.read_csv(f"data/analytics/{target_folder}/{base_data_name}",index_col=0)
 gb = GridOptionsBuilder.from_dataframe(shows)
 
 # ---


### PR DESCRIPTION
## Summary
- `streamlit/analytics.py` が `data/transactionhistory` という存在しないディレクトリを参照しており、`FileNotFoundError` が発生していた
- 実際のディレクトリ構成 (`data/analytics/transactionhistory`) に合わせてパスを修正。`app_estate.py` など他のページと同じ `data/analytics/` 配下を参照する規約に統一

## Test plan
- [x] コード上の参照パスが `data/analytics/{target_folder}` になっていることを確認
- [ ] `data/analytics/transactionhistory` に実データ(CSV)を配置した状態で `streamlit run analytics.py` を実行し、エラーが解消することを確認(実データが手元にないため未検証)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K1pP5JARCdyVEq3Y5tFvWp)_