### PR TITLE
app_estate.pyでデータフォルダ内のCSVを選択できるように変更

### DIFF
--- a/streamlit/pages/app_estate.py
+++ b/streamlit/pages/app_estate.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 import pydeck as pdk
 import pandas as pd
@@ -5,14 +6,15 @@ import numpy as np
 
 from utils import scale_color
 
-dataframe=pd.read_csv("data/analytics/activelist/mansionreview_20250727.csv",index_col=0)
-
-# Apply the function to create a color column
-dataframe['color'] = dataframe['坪単価'].apply(lambda x: scale_color(x))
+target_folder = "activelist"
 
 # 絞り込み条件の設定
 # Sidebar for external website
 with st.sidebar:
+    base_data_name=st.selectbox(
+    '対象のデータ',
+    [f for f in os.listdir(f"data/analytics/{target_folder}") if f.endswith(".csv")])
+
     mapstyle=st.selectbox(
     '地図のスタイル',
     [
@@ -22,6 +24,12 @@ with st.sidebar:
         'navigation-night-v1',
     ])
 
+dataframe=pd.read_csv(f"data/analytics/{target_folder}/{base_data_name}",index_col=0)
+
+# Apply the function to create a color column
+dataframe['color'] = dataframe['坪単価'].apply(lambda x: scale_color(x))
+
+with st.sidebar:
     min_area = dataframe['area'].min()
     max_area = min(150.0,dataframe['area'].max())
     price_range = st.slider(


### PR DESCRIPTION
## Summary
- `app_estate.py` が `data/analytics/activelist/mansionreview_20250727.csv` という固定ファイルを直接読んでいたのを変更
- `analytics.py` と同様に、`data/analytics/activelist` 配下のCSVファイル一覧をサイドバーのセレクトボックスから選択できるようにした

## Test plan
- [x] `data/analytics/activelist` にテスト用CSVを配置し、`uv run streamlit run streamlit/Home.py` で `app_estate` ページを開き、「対象のデータ」セレクトボックスが表示され、選択したCSVの内容(面積・築年数の範囲)が正しく反映されることをPlaywrightで確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01K1pP5JARCdyVEq3Y5tFvWp)_