### PR TITLE
load.pyでsuumoサイトを実行できるように修正

### DIFF
--- a/load.py
+++ b/load.py
@@ -15,6 +15,7 @@ EXTRACT_FUNCTIONS = {
 
 TRANSFORM_FUNCTIONS = {
     "mansionreview": transform_mansionreview.transform,
+    "suumo": transform_suumo.transform,
 }
 
 def validate_data(data):
@@ -46,14 +47,14 @@ def main(site_name):
     else:
         raise ValueError(f"Data from {site_name} is invalid.")
     
-    result.to_csv(now.strftime("data/rawdata/activelist/mansionreview_%Y%m%d.csv"))
+    result.to_csv(now.strftime(f"data/rawdata/activelist/{site_name}_%Y%m%d.csv"))
 
     if site_name in TRANSFORM_FUNCTIONS:
         transformed = TRANSFORM_FUNCTIONS[site_name](result)
     else:
         raise ValueError(f"TransformError: Unknown site '{site_name}'. Available sites: {list(TRANSFORM_FUNCTIONS.keys())}")
 
-    transformed.to_csv(now.strftime("data/analytics/activelist/mansionreview_%Y%m%d.csv"))
+    transformed.to_csv(now.strftime(f"data/analytics/activelist/{site_name}_%Y%m%d.csv"))
 
 if __name__ == "__main__":
     # コマンドライン引数からサイト名を取得

--- a/transform/suumo.py
+++ b/transform/suumo.py
@@ -1,0 +1,11 @@
+from .utils import get_lat_lon
+
+def transform(data):
+
+    data["坪単価"] = data["price"] / 10000 / data["area"] * 3.306
+
+    lons,lats=get_lat_lon(data["address"].values)
+    data["lons"]=lons
+    data["lats"]=lats
+
+    return data


### PR DESCRIPTION
- transform/suumo.pyを実装（lons/lats付与、坪単価計算を追加）
- load.pyのTRANSFORM_FUNCTIONSにsuumoを登録
- 出力ファイル名がmansionreview固定になっていたバグを修正し、site_nameを反映