### PR TITLE
Refactor scraping logic into reusable common module

### DIFF
--- a/extract/mansionreview.py
+++ b/extract/mansionreview.py
@@ -1,75 +1,92 @@
-from bs4 import BeautifulSoup
-from multiprocessing import Pool
-from tqdm import tqdm
 import pandas as pd
 import re
 from datetime import datetime
 
-from .utils import load_page
+from .scraping_common import fetch_soup, get_max_pages, scrape_paginated
+
+# ここから物件1件分のHTMLから各項目を抜き出す関数
+
+def extract_building_name(bukken):
+    return bukken.find("h2",class_="property-detail-content__head-title").text
+
+def extract_main_table(bukken):
+    return [cell.get_text(strip=True) for cell in bukken.find("table",class_="property-detail-content_main").find_all("td")]
+
+def extract_sub_table(bukken):
+    return [cell.get_text(strip=True) for cell in bukken.find("table",class_="property-detail-content_sub").find_all("td")]
+
+def extract_rooms_info(bukken):
+    return bukken.find("table",class_="recommendTable").find_all("tr")[1:]
+
+def extract_age(construction_date):
+    built_year, built_month = map(int, construction_date[:-1].split("年"))
+    return (datetime.now().year - built_year) + (datetime.now().month - built_month) / 12
+
+def extract_price(price_text):
+    return int(re.sub(r'[万円,]', '', price_text))
+
+def extract_area(area_text):
+    return float(re.sub(r'[m²,]', '', area_text))
+
+def extract_eva(eva_text):
+    eva_text = eva_text.strip()
+    return int(re.sub(r'[万円割安,]', '', eva_text)) if eva_text not in ["相応","評価中"] else 0
 
 def scrap_from_search(url):
-    
-    html = load_page(url)
-    soup = BeautifulSoup(html.content, 'html.parser')
+    soup = fetch_soup(url)
 
-    bukken_list=[bukken for bukken in soup.find_all("li",class_="property-detail-list-item")]
+    bukken_list=soup.find_all("li",class_="property-detail-list-item")
     bukken_results=[]
 
     for bukken in bukken_list:
-        building_name=bukken.find("h2",class_="property-detail-content__head-title").text
-        address,_,construction_date,floor_max_min,num_rooms=[cell.get_text(strip=True) for cell in bukken.find("table",class_="property-detail-content_main").find_all("td")]
-        _,_,_,_,_,_=[cell.get_text(strip=True) for cell in bukken.find("table",class_="property-detail-content_sub").find_all("td")]
+        building_name=extract_building_name(bukken)
+        address,_,construction_date,floor_max_min,num_rooms=extract_main_table(bukken)
+        extract_sub_table(bukken)#現状未使用だが、テーブルが存在することの確認も兼ねている
+        age=extract_age(construction_date)
 
-        rooms_info=[cell for cell in bukken.find("table",class_="recommendTable").find_all("tr")][1:]
-    
-        for room_info in rooms_info:
+        for room_info in extract_rooms_info(bukken):
             infos=[info.text for info in room_info.find_all("td")]
-            
+
             if len(infos)!=9:
                 continue
-            
+
             _,_,price,unit_price,area,room_type,num_floor,dire,eva=infos
-        
+
+            price=extract_price(price)
+            area=extract_area(area)
+
             bukken_results.append([
                 building_name,
-                int(re.sub(r'[万円,]', '', price)),
+                price,
                 address,
-                (lambda y, m: (datetime.now().year - y) + (datetime.now().month - m) / 12)(*map(int, construction_date[:-1].split("年"))),
-                float(re.sub(r'[m²,]', '', area)),
-                int(re.sub(r'[万円,]', '', price))/float(re.sub(r'[m²,]', '', area))*3.306,
+                age,
+                area,
+                price/area*3.306,
                 room_type,
                 num_floor,
                 dire,
-                int(re.sub(r'[万円割安,]', '', eva.strip(),)) if eva.strip() not in ["相応","評価中"] else 0,
+                extract_eva(eva),
                 re.sub(r'\s+', '', floor_max_min),
                 num_rooms,
             ])
-    
+
     return bukken_results
 
 
 def scrap_estate_data():
     WARD_NUM=23
+    df_columns=["name","price","address","age","area","坪単価","部屋のタイプ","階数","向き","割安額","n階建て","戸数"]
 
     results_all=[]
     for n_ward in range(WARD_NUM):
         origin_url=f"https://www.mansion-review.jp/mansion/city/{659+n_ward}.html"
-        html = load_page(origin_url)
-        soup = BeautifulSoup(html.content, 'html.parser')
+        soup = fetch_soup(origin_url)
 
-        MAX_PAGES=int(soup.find_all("li",class_="c-pagination-list__item")[-1].text.strip())
+        MAX_PAGES = get_max_pages(soup, "li.c-pagination-list__item")
 
-        url="https://www.mansion-review.jp/mansion/city/{}_{}.html"
-        
-        with Pool(processes=8) as pool:
-            with tqdm(total=MAX_PAGES-1) as pbar:
-                for result in pool.imap(scrap_from_search, [url.format(659+n_ward,num) for num in range(1,MAX_PAGES)]):
-                    results_all.extend(result)
-                    pbar.update(1)        
-        
-        #["name","price","address","area","age"]が必須?
-        df_columns=["name","price","address","age","area","坪単価","部屋のタイプ","階数","向き","割安額","n階建て","戸数"]
-        
+        url="https://www.mansion-review.jp/mansion/city/{}_{}.html".format(659+n_ward,"{}")
+
+        results_all.extend(scrape_paginated(url, MAX_PAGES, scrap_from_search, processes=8))
 
     return pd.DataFrame(results_all,columns=df_columns)
 

--- a/extract/scraping_common.py
+++ b/extract/scraping_common.py
@@ -1,0 +1,23 @@
+from bs4 import BeautifulSoup
+from multiprocessing import Pool
+from tqdm import tqdm
+
+from .utils import load_page
+
+def fetch_soup(url):
+    html = load_page(url)
+    return BeautifulSoup(html.content, 'html.parser')
+
+def get_max_pages(soup, css_selector):
+    return int(soup.select(css_selector)[-1].get_text(strip=True))
+
+def scrape_paginated(url_format, max_pages, parse_page, processes=8, start_page=1):
+    results_all = []
+    with Pool(processes=processes) as pool:
+        with tqdm(total=max_pages - start_page) as pbar:
+            urls = [url_format.format(num) for num in range(start_page, max_pages)]
+            for result in pool.imap(parse_page, urls):
+                results_all.extend(result)
+                pbar.update(1)
+
+    return results_all

--- a/extract/suumo.py
+++ b/extract/suumo.py
@@ -1,11 +1,8 @@
 import pandas as pd
 import re
 from datetime import datetime
-from bs4 import BeautifulSoup
-from multiprocessing import Pool
-from tqdm import tqdm
 
-from .utils import load_page
+from .scraping_common import fetch_soup, get_max_pages, scrape_paginated
 
 # 面積を抽出する関数
 def extract_area(text):
@@ -52,10 +49,7 @@ def calculate_age(built_date):
     return age_years,age_months
 
 def read_page(page_url):
-    #ここで並列化したい
-
-    html = load_page(page_url)
-    soup = BeautifulSoup(html.content, 'html.parser')
+    soup = fetch_soup(page_url)
     estates_groups = soup.find("div",class_='property_unit_group')
     estates = estates_groups.find_all('div', class_='property_unit')
 
@@ -92,16 +86,10 @@ def read_page(page_url):
 def get_estate_data():
     # SUUMOを東京都23区のみ指定して検索して出力した画面のurl(ページ数フォーマットが必要)
     url = "https://suumo.jp/jj/bukken/ichiran/JJ010FJ001/?ar=030&bs=011&ta=13&jspIdFlg=patternShikugun&sc=13101&sc=13102&sc=13103&sc=13104&sc=13105&sc=13113&sc=13106&sc=13107&sc=13108&sc=13118&sc=13121&sc=13122&sc=13123&sc=13109&sc=13110&sc=13111&sc=13112&sc=13114&sc=13115&sc=13120&sc=13116&sc=13117&sc=13119&kb=1&kt=9999999&mb=0&mt=9999999&ekTjCd=&ekTjNm=&tj=0&cnb=0&cn=9999999&srch_navi={{2}}&page={}"
-    html = load_page(url.format(1))#1ページ目を取得してページ数を取得
-    soup = BeautifulSoup(html.content, 'html.parser')
-    MAX_PAGES=int(soup.find("ol",class_="pagination-parts").find_all("li")[-1].text)
+    soup = fetch_soup(url.format(1))#1ページ目を取得してページ数を取得
+    MAX_PAGES = get_max_pages(soup, "ol.pagination-parts li")
 
-    with Pool(processes=3) as pool:
-        results_all=[]
-        with tqdm(total=MAX_PAGES) as pbar:
-            for result in pool.imap(read_page, [url.format(num) for num in range(1,MAX_PAGES)]):
-                results_all.extend(result)
-                pbar.update(1)
+    results_all = scrape_paginated(url, MAX_PAGES, read_page, processes=3)
 
     return pd.DataFrame(results_all,columns=["name","price","address","area","age","age_months"])
 


### PR DESCRIPTION
## Summary
Extracted common web scraping patterns into a new `scraping_common.py` module to reduce code duplication and improve maintainability across multiple scraping scripts.

## Key Changes
- **Created `scraping_common.py`** with three reusable utility functions:
  - `fetch_soup(url)`: Centralized HTML fetching and BeautifulSoup parsing
  - `get_max_pages(soup, css_selector)`: Generic pagination detection using CSS selectors
  - `scrape_paginated(url_format, max_pages, parse_page, processes, start_page)`: Unified parallel scraping with progress tracking

- **Refactored `mansionreview.py`**:
  - Extracted property data extraction logic into dedicated functions (`extract_building_name`, `extract_main_table`, `extract_sub_table`, `extract_rooms_info`, `extract_age`, `extract_price`, `extract_area`, `extract_eva`)
  - Replaced manual BeautifulSoup/multiprocessing code with calls to common utilities
  - Simplified `scrap_estate_data()` by delegating pagination and parallel processing to `scrape_paginated()`
  - Improved code readability with clearer variable names and reduced inline lambda expressions

- **Refactored `suumo.py`**:
  - Replaced manual HTML fetching and BeautifulSoup instantiation with `fetch_soup()`
  - Replaced manual pagination detection with `get_max_pages()`
  - Replaced manual multiprocessing Pool/tqdm logic with `scrape_paginated()`
  - Reduced `get_estate_data()` from 15 lines to 5 lines

## Implementation Details
- The `scrape_paginated()` function accepts a URL format string with `{}` placeholder for page numbers, allowing flexible URL construction
- CSS selector-based pagination detection in `get_max_pages()` is more flexible than hardcoded HTML class names
- All scraping functions maintain backward compatibility with existing data structures

https://claude.ai/code/session_01KQdyj279zBmptD3VXXPxA1